### PR TITLE
ApplicationAssembly was not returning the current assembly

### DIFF
--- a/ApplicationAssemblyUtility.cs
+++ b/ApplicationAssemblyUtility.cs
@@ -80,7 +80,7 @@ namespace eSpares.Levity
         {
             if (context == null) throw new ArgumentNullException("context");
 
-            var handler = context.CurrentHandler;
+            var handler = context.ApplicationInstance;
             if (handler == null) return null;
 
             var type = handler.GetType();


### PR DESCRIPTION
CurrentHandler is a System.Web.Mvc type for MVC applications, whereas
ApplicationInstance is always the actual ASP application
